### PR TITLE
factory and store can work with InputStream as well

### DIFF
--- a/src/main/java/org/geotools/data/dxf/DXFDataStore.java
+++ b/src/main/java/org/geotools/data/dxf/DXFDataStore.java
@@ -17,6 +17,7 @@ import org.opengis.filter.Filter;
 
 import java.awt.geom.AffineTransform;
 import java.io.IOException;
+import java.io.InputStream;
 import java.net.URL;
 import java.util.ArrayList;
 
@@ -36,6 +37,7 @@ import java.util.ArrayList;
  * @source $URL: http://svn.osgeo.org/geotools/branches/2.7.x/build/maven/javadoc/../../../modules/unsupported/dxf/src/main/java/org/geotools/data/dxf/DXFDataStore.java $
  */
 public class DXFDataStore extends AbstractFileDataStore {
+    private InputStream stream;
     private URL url;
     private FeatureReader featureReader;
     private String srs;
@@ -46,10 +48,15 @@ public class DXFDataStore extends AbstractFileDataStore {
     private AffineTransform transform;
 
     public DXFDataStore(URL url, String srs, AffineTransform transform) throws IOException {
-        this(url, srs, null, transform);
+        this(url, null, srs, null, transform);
     }
 
-    public DXFDataStore(URL url, String srs, String targetSrs, AffineTransform transform) throws IOException {
+    public DXFDataStore(InputStream stream, String srs, AffineTransform transform) throws IOException {
+        this(null, stream, srs, null, transform);
+    }
+
+    public DXFDataStore(URL url, InputStream stream, String srs, String targetSrs, AffineTransform transform) throws IOException {
+        this.stream = stream;
         this.url = url;
         this.strippedFileName = getURLTypeName(url);
         this.srs = srs;
@@ -73,6 +80,9 @@ public class DXFDataStore extends AbstractFileDataStore {
     }
 
     static String getURLTypeName(URL url) throws IOException {
+        if (url == null) {
+            return "";
+        }
         String file = url.getFile();
         if (file.length() == 0) {
             return "unknown_dxf";
@@ -149,7 +159,7 @@ public class DXFDataStore extends AbstractFileDataStore {
 
         if (featureReader == null) {
             try {
-                featureReader = new DXFFeatureReader(url, typeName, srs, targetSrs, geometryType, dxfInsertsFilter, transform);
+                featureReader = new DXFFeatureReader(url, stream, typeName, srs, targetSrs, geometryType, dxfInsertsFilter, transform);
             } catch (DXFParseException e) {
                 throw new IOException("DXF parse exception" + e.getLocalizedMessage());
             }

--- a/src/main/java/org/geotools/data/dxf/DXFFeatureReader.java
+++ b/src/main/java/org/geotools/data/dxf/DXFFeatureReader.java
@@ -78,14 +78,18 @@ public class DXFFeatureReader implements FeatureReader {
     private AffineTransform2D transform = null;
     private MathTransform crsTransform = null;
 
-    public DXFFeatureReader(URL url, String typeName, String srs, String targetCrs, GeometryType geometryType, ArrayList dxfInsertsFilter, AffineTransform transform) throws IOException, DXFParseException {
+    public DXFFeatureReader(URL url, InputStream stream, String typeName, String srs, String targetCrs, GeometryType geometryType, ArrayList dxfInsertsFilter, AffineTransform transform) throws IOException, DXFParseException {
         InputStream cis = null;
         DXFLineNumberReader lnr = null;
         if (transform != null)
             this.transform = new AffineTransform2D(transform);
 
         try {
-            cis = new BufferedInputStream(url.openStream(), 64 * 1024);
+            if (stream != null) {
+                cis = new BufferedInputStream(stream, 64 * 1024);
+            } else {
+                cis = new BufferedInputStream(url.openStream(), 64 * 1024);
+            }
             cis.mark(9192);
             try {
                 GZIPInputStream gzip = new GZIPInputStream(cis, 64 * 1024);
@@ -93,7 +97,7 @@ public class DXFFeatureReader implements FeatureReader {
             } catch (IOException ex) {
                 try {
                     cis.reset();
-                    if (url.getFile().toString().toLowerCase().endsWith(".zip")) {
+                    if (url != null && url.getFile().toString().toLowerCase().endsWith(".zip")) {
                         ZipInputStream zip = new ZipInputStream(cis);
                         if (zip.getNextEntry() != null)
                             cis = zip;


### PR DESCRIPTION
With an InputStream the reading/parsing can be done fully in the memory, without the need of a temporary file. (for example, when the library is being used in an API)

Example (in Java):

```java
var dxfInputStream = new FileInputStream("testfile.dxf"); // input stream can come from anywhere
var factory = new DXFDataStoreFactory();
var map = new HashMap<String, Object>();

map.put(DXFDataStoreFactory.PARAM_SRS.key, "EPSG:4326");
map.put(DXFDataStoreFactory.PARAM_TARGET_SRS.key, "EPSG:4326");
map.put(DXFDataStoreFactory.PARAM_AFFINE_TRANSFORM.key, new AffineTransform());
map.put(DXFDataStoreFactory.PARAM_INPUT_STREAM.key, dxfInputStream);

var store = factory.createDataStore(map);
var featureSource = store.getFeatureSource();
```