### PR TITLE
Use HTTPS instead of plain HTTP with Maven

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -74,12 +74,12 @@
         <repository>
             <id>maven2-repository.dev.java.net</id>
             <name>Java.net repository</name>
-            <url>http://download.java.net/maven/2</url>
+            <url>https://download.java.net/maven/2</url>
         </repository>
         <repository>
             <id>osgeo</id>
             <name>Open Source Geospatial Foundation Repository</name>
-	    <url>http://repo.osgeo.org/repository/release/</url>
+	    <url>https://repo.osgeo.org/repository/release/</url>
         </repository>
         <repository>
             <id>central</id>
@@ -92,7 +92,7 @@
           </snapshots>
           <id>boundless</id>
           <name>Boundless Maven Repository</name>
-          <url>http://repo.boundlessgeo.com/main</url>
+          <url>https://repo.boundlessgeo.com/main</url>
         </repository>	
     </repositories>  
 


### PR DESCRIPTION
Latest version of Maven 3 will block HTTP repositories by default. Updated the pom.xml to use HTTPS.